### PR TITLE
Use async httpx for Ollama HTTP fallback

### DIFF
--- a/backend/app/core/llm_adapter.py
+++ b/backend/app/core/llm_adapter.py
@@ -13,7 +13,7 @@ try:
 except Exception:
     ollama = None
 
-import requests
+import httpx
 
 
 class LLMAdapter:
@@ -48,7 +48,7 @@ class LLMAdapter:
         """Check if an Ollama server responds to a simple request."""
         try:
             url = self.ollama_base.rstrip("/") + "/api/tags"
-            requests.get(url, timeout=2)
+            httpx.get(url, timeout=2)
             return True
         except Exception:
             return False
@@ -118,7 +118,10 @@ class LLMAdapter:
 
         # Fallback to HTTP
         url = self.ollama_base.rstrip("/") + "/api/chat"
-        resp = requests.post(url, json={"model": self.model, "messages": messages}, timeout=30)
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                url, json={"model": self.model, "messages": messages}, timeout=30
+            )
         resp.raise_for_status()
         body = resp.json()
         if isinstance(body, dict):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,4 +5,4 @@ python-multipart==0.0.6
 pypdf==3.17.1
 openai==1.3.7
 python-dotenv==1.0.0
-requests==2.31.0
+httpx==0.26.0


### PR DESCRIPTION
## Summary
- switch Ollama HTTP fallback to async httpx client so calls don't block the event loop
- drop unused requests dependency and add httpx

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60b2c1de8832fa7493f48b514e7f4