### PR TITLE
Run OCR in a background thread

### DIFF
--- a/backend/app/core/ocr.py
+++ b/backend/app/core/ocr.py
@@ -1,4 +1,4 @@
-from typing import Optional
+import asyncio
 import pdfplumber
 import pytesseract
 from PIL import Image
@@ -22,31 +22,29 @@ class OCRProcessor:
 
         pytesseract.pytesseract.tesseract_cmd = tesseract_cmd
 
+    def _process_pdf(self, file_content: bytes) -> str:
+        """Blocking PDF/OCR logic split into a helper for thread execution."""
+        with pdfplumber.open(io.BytesIO(file_content)) as pdf:
+            text_content = []
+
+            for page in pdf.pages:
+                text = page.extract_text() or ""
+                if len(text.strip()) < 50:  # Arbitrary threshold
+                    img = page.to_image()
+                    pil_image = Image.frombytes(
+                        mode="RGB",
+                        size=(img.width, img.height),
+                        data=img.original.tobytes(),
+                    )
+                    text = pytesseract.image_to_string(pil_image) or ""
+
+                text_content.append(text.strip())
+
+            return "\n\n".join(text_content)
+
     async def extract_text(self, file_content: bytes) -> str:
         """Extract text from a PDF file using pdfplumber and pytesseract for images."""
         try:
-            with pdfplumber.open(io.BytesIO(file_content)) as pdf:
-                text_content = []
-                
-                for page in pdf.pages:
-                    # Extract text content
-                    text = page.extract_text() or ""
-                    
-                    # If page has little or no text, try OCR on the page image
-                    if len(text.strip()) < 50:  # Arbitrary threshold
-                        img = page.to_image()
-                        # Convert to PIL Image
-                        pil_image = Image.frombytes(
-                            mode='RGB',
-                            size=(img.width, img.height),
-                            data=img.original.tobytes()
-                        )
-                        # Perform OCR
-                        text = pytesseract.image_to_string(pil_image) or ""
-                    
-                    text_content.append(text.strip())
-                
-                return "\n\n".join(text_content)
-                
+            return await asyncio.to_thread(self._process_pdf, file_content)
         except Exception as e:
             raise Exception(f"Failed to process PDF: {str(e)}")


### PR DESCRIPTION
## Summary
- Offload blocking PDF/OCR work to a `_process_pdf` helper
- Use `asyncio.to_thread` in `extract_text` to await thread execution
- Keep existing exception handling for PDF processing errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a60c3a911c832fbd83e0060ac0d207