### PR TITLE
feat: add rule-based compliance checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ yarn-error.log*
 # OS
 .DS_Store
 Thumbs.db
+
+out/

--- a/check.ps1
+++ b/check.ps1
@@ -1,0 +1,12 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Chunks,
+    [Parameter(Mandatory=$true)][string]$Rules,
+    [Parameter(Mandatory=$true)][string]$Out
+)
+
+$directory = Split-Path $Out -Parent
+if (-not (Test-Path $directory)) {
+    New-Item -ItemType Directory -Path $directory | Out-Null
+}
+
+python -m engine.cli --chunks $Chunks --rules $Rules --out $Out

--- a/data/chunks.jsonl
+++ b/data/chunks.jsonl
@@ -1,0 +1,5 @@
+{"chunk_id": "1", "text": "The personal data must be collected with explicit consent from the user."}
+{"chunk_id": "2", "text": "We retain customer information for ten years."}
+{"chunk_id": "3", "text": "Users may request access or rectification of their data."}
+{"chunk_id": "4", "text": "Data is transferred to processors outside the EU."}
+{"chunk_id": "5", "text": "General terms and conditions."}

--- a/engine/cli.py
+++ b/engine/cli.py
@@ -1,0 +1,41 @@
+import argparse
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+from .rules import load_rules
+from .executors import execute_rules
+
+
+def load_chunks(path: str) -> List[Dict[str, Any]]:
+    chunks: List[Dict[str, Any]] = []
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            chunks.append(json.loads(line))
+    return chunks
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Compliance checker')
+    parser.add_argument('--chunks', required=True, help='Path to chunks JSONL file')
+    parser.add_argument('--rules', required=True, help='Path to rules YAML file')
+    parser.add_argument('--out', required=True, help='Where to write findings JSON')
+    args = parser.parse_args()
+
+    rules = load_rules(args.rules)
+    chunks = load_chunks(args.chunks)
+    findings = execute_rules(rules, chunks)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, 'w', encoding='utf-8') as f:
+        json.dump(findings, f, indent=2)
+
+    print(f"Wrote {len(findings)} findings to {args.out}")
+
+
+if __name__ == '__main__':
+    main()

--- a/engine/executors.py
+++ b/engine/executors.py
@@ -1,0 +1,31 @@
+import re
+from typing import Iterable, Dict, Any, List
+from .rules import Rule
+
+
+def execute_rules(rules: Iterable[Rule], chunks: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Apply rules to chunks and return list of findings."""
+    findings: List[Dict[str, Any]] = []
+    for chunk in chunks:
+        chunk_id = chunk.get('chunk_id')
+        text = chunk.get('text', '')
+        for rule in rules:
+            if rule.is_regex() and rule.pattern:
+                match = re.search(rule.pattern, text, flags=re.IGNORECASE)
+                if match:
+                    findings.append({
+                        'rule_id': rule.id,
+                        'chunk_id': chunk_id,
+                        'snippet': match.group(0),
+                        'severity': rule.severity,
+                    })
+            elif rule.is_keyword() and rule.keywords:
+                lowered = text.lower()
+                if all(kw.lower() in lowered for kw in rule.keywords):
+                    findings.append({
+                        'rule_id': rule.id,
+                        'chunk_id': chunk_id,
+                        'snippet': text,
+                        'severity': rule.severity,
+                    })
+    return findings

--- a/engine/rules.py
+++ b/engine/rules.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import List, Optional
+import yaml
+
+
+@dataclass
+class Rule:
+    """Representation of a compliance rule loaded from YAML."""
+    id: str
+    title: str
+    severity: str
+    guidance: str
+    citations: List[str]
+    pattern: Optional[str] = None
+    keywords: Optional[List[str]] = None
+
+    def is_regex(self) -> bool:
+        return self.pattern is not None
+
+    def is_keyword(self) -> bool:
+        return self.keywords is not None
+
+
+def load_rules(path: str) -> List[Rule]:
+    """Load a YAML rule file into a list of Rule objects."""
+    with open(path, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f) or []
+
+    rules: List[Rule] = []
+    for raw in data:
+        rule = Rule(
+            id=raw['id'],
+            title=raw.get('title', ''),
+            severity=raw.get('severity', 'medium'),
+            guidance=raw.get('guidance', ''),
+            citations=raw.get('citations', []),
+            pattern=raw.get('pattern'),
+            keywords=raw.get('keywords'),
+        )
+        rules.append(rule)
+    return rules

--- a/rules/gdpr.yaml
+++ b/rules/gdpr.yaml
@@ -1,0 +1,35 @@
+- id: gdpr-001
+  title: Personal data consent required
+  keywords: ["personal data", "consent"]
+  severity: high
+  guidance: Obtain explicit consent before processing personal data.
+  citations:
+    - GDPR Art. 7
+- id: gdpr-002
+  title: Data retention limits
+  pattern: "retain|retention"
+  severity: medium
+  guidance: Specify retention periods for stored data.
+  citations:
+    - GDPR Art. 5(1)(e)
+- id: gdpr-003
+  title: Data subject rights
+  keywords: ["access", "rectification"]
+  severity: medium
+  guidance: Provide mechanisms for data subject rights requests.
+  citations:
+    - GDPR Chapter 3
+- id: gdpr-004
+  title: International data transfers
+  pattern: "transfer.*outside the EU|transfer.*third country"
+  severity: high
+  guidance: Ensure safeguards for transfers outside the EU.
+  citations:
+    - GDPR Chapter 5
+- id: gdpr-005
+  title: Breach notification
+  pattern: "breach"
+  severity: high
+  guidance: Notify authorities of personal data breaches within 72 hours.
+  citations:
+    - GDPR Art. 33

--- a/rules/uk_ics.yaml
+++ b/rules/uk_ics.yaml
@@ -1,0 +1,35 @@
+- id: ukics-001
+  title: Marketing permissions
+  pattern: "marketing"
+  severity: low
+  guidance: Keep records of marketing permissions.
+  citations:
+    - UK ICO PECR
+- id: ukics-002
+  title: Child data consent
+  keywords: ["child", "consent"]
+  severity: high
+  guidance: Obtain parental consent for processing children's data.
+  citations:
+    - UK GDPR Art. 8
+- id: ukics-003
+  title: Right to object
+  keywords: ["object", "processing"]
+  severity: medium
+  guidance: Provide a clear right to object to processing.
+  citations:
+    - UK GDPR Art. 21
+- id: ukics-004
+  title: Security measures
+  pattern: "encryption|secure"
+  severity: medium
+  guidance: Implement appropriate technical security measures.
+  citations:
+    - UK GDPR Art. 32
+- id: ukics-005
+  title: Data Protection Officer
+  keywords: ["data protection officer"]
+  severity: low
+  guidance: Appoint a DPO when required.
+  citations:
+    - UK GDPR Art. 37


### PR DESCRIPTION
## Summary
- add extensible rule engine with regex and keyword matchers
- include sample GDPR and UK-ICS rulesets in YAML
- provide CLI and PowerShell wrapper for contract chunk checks

## Testing
- `pwsh ./check.ps1 -Chunks ./data/chunks.jsonl -Rules ./rules/gdpr.yaml -Out ./out/findings.json` *(fails: command not found)*
- `python -m engine.cli --chunks ./data/chunks.jsonl --rules ./rules/gdpr.yaml --out ./out/findings.json`


------
https://chatgpt.com/codex/tasks/task_e_68a63a099594832faea6df13b3490123