### PR TITLE
feat: add heuristic fallback for contract review

### DIFF
--- a/backend/tests/test_review_endpoint.py
+++ b/backend/tests/test_review_endpoint.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+def test_review_endpoint_returns_results():
+    client = TestClient(app)
+    pdf_path = Path("backend/tests/fixtures/uk_nda.pdf")
+    with pdf_path.open("rb") as f:
+        files = {"file": ("uk_nda.pdf", f, "application/pdf")}
+        resp = client.post("/api/review", files=files)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["summary"]
+    assert isinstance(data["risks"], list)
+    assert data["risks"]


### PR DESCRIPTION
## Summary
- add simple heuristic summary and risk extraction when no LLM backend is configured
- cover `/api/review` endpoint with test using NDA fixture

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a63ca1e554832fa799048f3a3fd641