### PR TITLE
feat: add file upload and status components

### DIFF
--- a/frontend/components/file-upload.tsx
+++ b/frontend/components/file-upload.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+import { useDropzone, FileRejection } from 'react-dropzone'
+
+interface FileUploadProps {
+  onFileSelect: (file: File) => void
+  maxSize?: number
+  acceptedTypes?: string[]
+}
+
+export function FileUpload({
+  onFileSelect,
+  maxSize = 10 * 1024 * 1024,
+  acceptedTypes = ['application/pdf']
+}: FileUploadProps) {
+  const [errors, setErrors] = useState<string[]>([])
+
+  const onDrop = useCallback(
+    (acceptedFiles: File[], rejectedFiles: FileRejection[]) => {
+      setErrors([])
+      if (rejectedFiles.length > 0) {
+        const errorMessages = rejectedFiles.map(({ errors }) =>
+          errors.map((e) => e.message).join(', ')
+        )
+        setErrors(errorMessages)
+        return
+      }
+      if (acceptedFiles.length > 0) {
+        onFileSelect(acceptedFiles[0])
+      }
+    },
+    [onFileSelect]
+  )
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    maxSize,
+    accept: {
+      'application/pdf': ['.pdf']
+    },
+    multiple: false
+  })
+
+  return (
+    <div className="w-full max-w-2xl mx-auto">
+      <div
+        {...getRootProps()}
+        className={`
+          relative border-2 border-dashed rounded-xl p-8 text-center cursor-pointer
+          transition-all duration-200 ease-in-out
+          ${isDragActive ? 'border-primary-500 bg-primary-50' : 'border-neutral-300 hover:border-primary-400 hover:bg-neutral-50'}
+          ${errors.length > 0 ? 'border-red-300 bg-red-50' : ''}
+        `}
+      >
+        <input {...getInputProps()} />
+        <div className="mb-4">
+          <svg className="mx-auto h-12 w-12 text-neutral-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+          </svg>
+        </div>
+        <div className="space-y-2">
+          <p className="text-lg font-medium text-neutral-900">
+            {isDragActive ? 'Drop your contract here' : 'Upload your contract'}
+          </p>
+          <p className="text-sm text-neutral-600">
+            Drag and drop a PDF file, or <span className="text-primary-600 font-medium">click to browse</span>
+          </p>
+          <p className="text-xs text-neutral-500">
+            Maximum file size: {(maxSize / 1024 / 1024).toFixed(0)}MB • PDF only
+          </p>
+        </div>
+      </div>
+      {errors.length > 0 && (
+        <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg">
+          <div className="flex items-center">
+            <svg className="h-5 w-5 text-red-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                clipRule="evenodd"
+              />
+            </svg>
+            <div>
+              {errors.map((error, index) => (
+                <p key={index} className="text-sm text-red-700">
+                  {error}
+                </p>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/processing-status.tsx
+++ b/frontend/components/processing-status.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import React from 'react'
+
+interface ProcessingStatusProps {
+  status: 'uploading' | 'extracting' | 'analyzing' | 'complete' | 'error'
+  progress?: number
+  fileName?: string
+  estimatedTime?: number
+}
+
+export function ProcessingStatus({
+  status,
+  progress = 0,
+  fileName,
+  estimatedTime
+}: ProcessingStatusProps) {
+  const statusConfig = {
+    uploading: {
+      icon: '⬆️',
+      title: 'Uploading contract',
+      description: 'Securely transferring your file...',
+      color: 'blue'
+    },
+    extracting: {
+      icon: '📄',
+      title: 'Extracting text',
+      description: 'Reading contract content...',
+      color: 'blue'
+    },
+    analyzing: {
+      icon: '🔍',
+      title: 'Analyzing contract',
+      description: 'AI is reviewing clauses and identifying risks...',
+      color: 'blue'
+    },
+    complete: {
+      icon: '✅',
+      title: 'Analysis complete',
+      description: 'Your contract review is ready',
+      color: 'green'
+    },
+    error: {
+      icon: '❌',
+      title: 'Processing failed',
+      description: 'Something went wrong. Please try again.',
+      color: 'red'
+    }
+  } as const
+
+  const config = statusConfig[status]
+
+  return (
+    <div className="w-full max-w-md mx-auto p-6 bg-white rounded-xl shadow-lg">
+      <div className="text-center mb-6">
+        <div className="text-4xl mb-2">{config.icon}</div>
+        <h3 className="text-lg font-semibold text-neutral-900">{config.title}</h3>
+        <p className="text-sm text-neutral-600 mt-1">{config.description}</p>
+        {fileName && <p className="text-xs text-neutral-500 mt-2 truncate">{fileName}</p>}
+      </div>
+      {status !== 'complete' && status !== 'error' && (
+        <div className="mb-4">
+          <div className="flex justify-between text-sm text-neutral-600 mb-2">
+            <span>Progress</span>
+            <span>{Math.round(progress)}%</span>
+          </div>
+          <div className="w-full bg-neutral-200 rounded-full h-2">
+            <div
+              className={`bg-${config.color}-500 h-2 rounded-full transition-all duration-500 ease-out`}
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      )}
+      {estimatedTime && status !== 'complete' && status !== 'error' && (
+        <div className="text-center text-sm text-neutral-500">
+          Estimated time remaining: {Math.ceil(estimatedTime / 60)} minutes
+        </div>
+      )}
+      {status !== 'complete' && status !== 'error' && (
+        <div className="flex justify-center mt-4">
+          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-600"></div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/lib/design-tokens.ts
+++ b/frontend/lib/design-tokens.ts
@@ -1,0 +1,70 @@
+export const designTokens = {
+  colors: {
+    primary: {
+      50: '#f0f9ff',
+      100: '#e0f2fe',
+      500: '#0ea5e9',
+      600: '#0284c7',
+      700: '#0369a1',
+      900: '#0c4a6e'
+    },
+    semantic: {
+      success: '#10b981',
+      warning: '#f59e0b',
+      error: '#ef4444',
+      info: '#3b82f6'
+    },
+    risk: {
+      low: '#10b981',
+      medium: '#f59e0b',
+      high: '#f97316',
+      critical: '#dc2626'
+    },
+    neutral: {
+      50: '#f8fafc',
+      100: '#f1f5f9',
+      200: '#e2e8f0',
+      500: '#64748b',
+      700: '#334155',
+      900: '#0f172a'
+    }
+  },
+  typography: {
+    fontFamily: {
+      sans: ['Inter', 'system-ui', 'sans-serif'],
+      mono: ['JetBrains Mono', 'monospace']
+    },
+    fontSize: {
+      xs: '0.75rem',
+      sm: '0.875rem',
+      base: '1rem',
+      lg: '1.125rem',
+      xl: '1.25rem',
+      '2xl': '1.5rem',
+      '3xl': '1.875rem',
+      '4xl': '2.25rem'
+    }
+  },
+  spacing: {
+    xs: '0.5rem',
+    sm: '0.75rem',
+    md: '1rem',
+    lg: '1.5rem',
+    xl: '2rem',
+    '2xl': '3rem',
+    '3xl': '4rem'
+  },
+  borderRadius: {
+    sm: '0.25rem',
+    md: '0.5rem',
+    lg: '0.75rem',
+    xl: '1rem',
+    full: '9999px'
+  },
+  shadows: {
+    sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
+    md: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
+    lg: '0 10px 15px -3px rgb(0 0 0 / 0.1)',
+    xl: '0 20px 25px -5px rgb(0 0 0 / 0.1)'
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "postcss": "^8",
         "react": "^18",
         "react-dom": "^18",
+        "react-dropzone": "^14.3.8",
         "recharts": "^3.1.2",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^3",
@@ -2137,6 +2138,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -3587,6 +3597,18 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/fill-range": {
@@ -5480,7 +5502,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5541,6 +5562,23 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-dropzone": {
+      "version": "14.3.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
+      "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "postcss": "^8",
     "react": "^18",
     "react-dom": "^18",
+    "react-dropzone": "^14.3.8",
     "recharts": "^3.1.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3",


### PR DESCRIPTION
## Summary
- add design tokens file for consistent styling
- add reusable FileUpload component with drag-and-drop support
- add ProcessingStatus component to show progress and outcomes

## Testing
- `PYTHONPATH=. pytest backend/tests/test_review_endpoint.py`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a645c67b40832fb8d6cb77001ec166