### PR TITLE
Improve design tokens and upload status components

### DIFF
--- a/frontend/components/file-upload.tsx
+++ b/frontend/components/file-upload.tsx
@@ -2,17 +2,20 @@
 
 import { useState, useCallback } from 'react'
 import { useDropzone, FileRejection } from 'react-dropzone'
+import { LoadingSpinner } from './loading-spinner'
 
 interface FileUploadProps {
   onFileSelect: (file: File) => void
   maxSize?: number
   acceptedTypes?: string[]
+  isLoading?: boolean
 }
 
 export function FileUpload({
   onFileSelect,
   maxSize = 10 * 1024 * 1024,
-  acceptedTypes = ['application/pdf']
+  acceptedTypes = ['application/pdf'],
+  isLoading = false,
 }: FileUploadProps) {
   const [errors, setErrors] = useState<string[]>([])
 
@@ -20,9 +23,24 @@ export function FileUpload({
     (acceptedFiles: File[], rejectedFiles: FileRejection[]) => {
       setErrors([])
       if (rejectedFiles.length > 0) {
-        const errorMessages = rejectedFiles.map(({ errors }) =>
-          errors.map((e) => e.message).join(', ')
-        )
+        const errorMessages: string[] = []
+        rejectedFiles.forEach(({ file, errors: rejectErrors }) => {
+          rejectErrors.forEach((err) => {
+            if (err.code === 'file-too-large') {
+              errorMessages.push(
+                `File "${file.name}" is too large. Max size is ${Math.round(maxSize / (1024 * 1024))}MB.`
+              )
+            } else if (err.code === 'file-invalid-type') {
+              errorMessages.push(
+                `File "${file.name}" has an unsupported type. Only ${acceptedTypes
+                  .map((t) => t.split('/')[1].toUpperCase())
+                  .join(', ')} files are allowed.`
+              )
+            } else {
+              errorMessages.push(`File "${file.name}" error: ${err.message}`)
+            }
+          })
+        })
         setErrors(errorMessages)
         return
       }
@@ -30,47 +48,100 @@ export function FileUpload({
         onFileSelect(acceptedFiles[0])
       }
     },
-    [onFileSelect]
+    [onFileSelect, maxSize, acceptedTypes]
   )
 
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+  const acceptedMimeTypes = acceptedTypes.reduce(
+    (acc, type) => {
+      const ext = type.split('/')[1]
+      return { ...acc, [type]: [`.${ext}`] }
+    },
+    {} as Record<string, string[]>
+  )
+
+  const {
+    getRootProps,
+    getInputProps,
+    isDragActive,
+    isDragAccept,
+    isDragReject,
+  } = useDropzone({
     onDrop,
     maxSize,
-    accept: {
-      'application/pdf': ['.pdf']
-    },
-    multiple: false
+    accept: acceptedMimeTypes,
+    multiple: false,
+    disabled: isLoading,
   })
+
+  const borderColor =
+    errors.length > 0
+      ? 'border-red-500'
+      : isDragAccept
+      ? 'border-primary-500'
+      : isDragReject
+      ? 'border-red-500'
+      : 'border-neutral-300'
+
+  const backgroundColor =
+    errors.length > 0
+      ? 'bg-red-50'
+      : isDragAccept
+      ? 'bg-primary-50'
+      : isDragReject
+      ? 'bg-red-50'
+      : 'hover:bg-neutral-50'
 
   return (
     <div className="w-full max-w-2xl mx-auto">
       <div
         {...getRootProps()}
-        className={`
-          relative border-2 border-dashed rounded-xl p-8 text-center cursor-pointer
-          transition-all duration-200 ease-in-out
-          ${isDragActive ? 'border-primary-500 bg-primary-50' : 'border-neutral-300 hover:border-primary-400 hover:bg-neutral-50'}
-          ${errors.length > 0 ? 'border-red-300 bg-red-50' : ''}
-        `}
+        className={`relative border-2 border-dashed rounded-xl p-8 text-center transition-all duration-200 ease-in-out ${borderColor} ${backgroundColor} ${
+          isLoading ? 'opacity-70 cursor-not-allowed' : 'cursor-pointer'
+        }`}
+        aria-disabled={isLoading}
       >
-        <input {...getInputProps()} />
+        <input {...getInputProps()} id="contract-upload" />
+
         <div className="mb-4">
-          <svg className="mx-auto h-12 w-12 text-neutral-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+          <svg
+            className="mx-auto h-12 w-12 text-neutral-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+            />
           </svg>
         </div>
+
         <div className="space-y-2">
           <p className="text-lg font-medium text-neutral-900">
-            {isDragActive ? 'Drop your contract here' : 'Upload your contract'}
+            {isLoading
+              ? 'Processing...'
+              : isDragActive
+              ? 'Drop your contract here'
+              : 'Upload your contract'}
           </p>
           <p className="text-sm text-neutral-600">
-            Drag and drop a PDF file, or <span className="text-primary-600 font-medium">click to browse</span>
+            Drag and drop a PDF file, or{' '}
+            <span className="text-primary-600 font-medium">click to browse</span>
           </p>
           <p className="text-xs text-neutral-500">
             Maximum file size: {(maxSize / 1024 / 1024).toFixed(0)}MB • PDF only
           </p>
         </div>
+
+        {isLoading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75 rounded-xl">
+            <LoadingSpinner className="text-primary-600 h-8 w-8" />
+          </div>
+        )}
       </div>
+
       {errors.length > 0 && (
         <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-lg">
           <div className="flex items-center">

--- a/frontend/components/loading-spinner.tsx
+++ b/frontend/components/loading-spinner.tsx
@@ -1,0 +1,24 @@
+export function LoadingSpinner({ className }: { className?: string }) {
+  return (
+    <svg
+      className={`animate-spin h-5 w-5 text-current ${className ?? ''}`}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      ></circle>
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      ></path>
+    </svg>
+  )
+}

--- a/frontend/components/processing-status.tsx
+++ b/frontend/components/processing-status.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import React from 'react'
+import { LoadingSpinner } from './loading-spinner'
+import { designTokens } from '@/lib/design-tokens'
 
 interface ProcessingStatusProps {
   status: 'uploading' | 'extracting' | 'analyzing' | 'complete' | 'error'
@@ -13,52 +15,71 @@ export function ProcessingStatus({
   status,
   progress = 0,
   fileName,
-  estimatedTime
+  estimatedTime,
 }: ProcessingStatusProps) {
   const statusConfig = {
     uploading: {
       icon: '⬆️',
       title: 'Uploading contract',
       description: 'Securely transferring your file...',
-      color: 'blue'
+      progressColor: 'bg-primary-500',
+      iconColor: 'text-primary-600',
     },
     extracting: {
       icon: '📄',
       title: 'Extracting text',
       description: 'Reading contract content...',
-      color: 'blue'
+      progressColor: 'bg-primary-500',
+      iconColor: 'text-primary-600',
     },
     analyzing: {
       icon: '🔍',
       title: 'Analyzing contract',
       description: 'AI is reviewing clauses and identifying risks...',
-      color: 'blue'
+      progressColor: 'bg-primary-500',
+      iconColor: 'text-primary-600',
     },
     complete: {
       icon: '✅',
       title: 'Analysis complete',
       description: 'Your contract review is ready',
-      color: 'green'
+      progressColor: 'bg-semantic-success',
+      iconColor: 'text-semantic-success',
     },
     error: {
       icon: '❌',
       title: 'Processing failed',
       description: 'Something went wrong. Please try again.',
-      color: 'red'
-    }
+      progressColor: 'bg-semantic-error',
+      iconColor: 'text-semantic-error',
+    },
   } as const
 
   const config = statusConfig[status]
+  const isProgressVisible = status !== 'complete' && status !== 'error'
+
+  const formatTime = (seconds?: number) => {
+    if (seconds === undefined || seconds < 0) return ''
+    const minutes = Math.floor(seconds / 60)
+    const remainingSeconds = seconds % 60
+    if (minutes > 0) {
+      return `${minutes} min${remainingSeconds > 0 ? ` ${remainingSeconds} sec` : ''}`
+    }
+    return `${remainingSeconds} sec`
+  }
 
   return (
     <div className="w-full max-w-md mx-auto p-6 bg-white rounded-xl shadow-lg">
       <div className="text-center mb-6">
-        <div className="text-4xl mb-2">{config.icon}</div>
+        <div className={`text-4xl mb-2 ${config.iconColor}`}>{config.icon}</div>
         <h3 className="text-lg font-semibold text-neutral-900">{config.title}</h3>
         <p className="text-sm text-neutral-600 mt-1">{config.description}</p>
-        {fileName && <p className="text-xs text-neutral-500 mt-2 truncate">{fileName}</p>}
+        {fileName && (
+          <p className="text-xs text-neutral-500 mt-2 truncate">File: {fileName}</p>
+        )}
       </div>
-      {status !== 'complete' && status !== 'error' && (
+
+      {isProgressVisible && (
         <div className="mb-4">
           <div className="flex justify-between text-sm text-neutral-600 mb-2">
             <span>Progress</span>
@@ -66,20 +87,26 @@ export function ProcessingStatus({
           </div>
           <div className="w-full bg-neutral-200 rounded-full h-2">
             <div
-              className={`bg-${config.color}-500 h-2 rounded-full transition-all duration-500 ease-out`}
+              className={`${config.progressColor} h-2 rounded-full ${designTokens.transition.duration} ${designTokens.transition.timing}`}
               style={{ width: `${progress}%` }}
+              role="progressbar"
+              aria-valuenow={progress}
+              aria-valuemin={0}
+              aria-valuemax={100}
             />
           </div>
         </div>
       )}
-      {estimatedTime && status !== 'complete' && status !== 'error' && (
-        <div className="text-center text-sm text-neutral-500">
-          Estimated time remaining: {Math.ceil(estimatedTime / 60)} minutes
+
+      {isProgressVisible && estimatedTime !== undefined && estimatedTime > 0 && (
+        <div className="text-center text-sm text-neutral-500 mt-2">
+          Estimated time remaining: {formatTime(estimatedTime)}
         </div>
       )}
-      {status !== 'complete' && status !== 'error' && (
+
+      {isProgressVisible && (
         <div className="flex justify-center mt-4">
-          <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-600"></div>
+          <LoadingSpinner className="h-6 w-6 text-primary-600" />
         </div>
       )}
     </div>

--- a/frontend/lib/design-tokens.ts
+++ b/frontend/lib/design-tokens.ts
@@ -3,6 +3,7 @@ export const designTokens = {
     primary: {
       50: '#f0f9ff',
       100: '#e0f2fe',
+      200: '#bfdbfe',
       500: '#0ea5e9',
       600: '#0284c7',
       700: '#0369a1',
@@ -63,8 +64,12 @@ export const designTokens = {
   },
   shadows: {
     sm: '0 1px 2px 0 rgb(0 0 0 / 0.05)',
-    md: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
-    lg: '0 10px 15px -3px rgb(0 0 0 / 0.1)',
-    xl: '0 20px 25px -5px rgb(0 0 0 / 0.1)'
+    md: '0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)',
+    lg: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+    xl: '0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)'
+  },
+  transition: {
+    duration: 'duration-300',
+    timing: 'ease-in-out'
   }
 }


### PR DESCRIPTION
## Summary
- expand design tokens with additional colors, shadows, and transition settings
- add reusable LoadingSpinner component
- enhance FileUpload and ProcessingStatus components with loading feedback and accessible progress

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (interactive setup prompt)


------
https://chatgpt.com/codex/tasks/task_e_68a6479a6df8832f9b15c3dc3cc40485