### PR TITLE
Add python-multipart dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ openai
 pydantic
 fastapi
 uvicorn
+python-multipart
 pypdf
 python-docx
 tiktoken


### PR DESCRIPTION
## Summary
- add missing python-multipart to top-level requirements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a651d822d4832f8fa8464cf769fbed