### PR TITLE
Add root status endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,12 @@ app.add_middleware(
 app.include_router(contracts.router, prefix="/api")
 app.include_router(dashboard.router, prefix="/api")
 
+# Root route for basic status check
+@app.get("/")
+async def root():
+    """Root endpoint returning a simple status message."""
+    return {"status": "Blackletter Systems API running"}
+
 # Health check
 @app.get("/health")
 async def health_check():

--- a/blackletter-systems/backend/main.py
+++ b/blackletter-systems/backend/main.py
@@ -189,6 +189,11 @@ def analyze_contract_with_llm(contract_text: str, filename: Optional[str] = None
     
     return issues
 
+@app.get("/")
+async def root() -> Dict[str, str]:
+    """Root endpoint providing a simple service message."""
+    return {"message": "Blackletter API running"}
+
 @app.get("/health")
 def health():
     return {"ok": True, "service": "blackletter", "ts": datetime.utcnow().isoformat()}


### PR DESCRIPTION
## Summary
- add root endpoint to main backend app for status message
- add root endpoint to legacy blackletter systems backend

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a655a31140832f92431a9bc6886bce