### PR TITLE
feat: add HTML landing page for API root

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
 from .routers import contracts, dashboard
 
 app = FastAPI(title="Blackletter Systems API")
@@ -18,10 +19,20 @@ app.include_router(contracts.router, prefix="/api")
 app.include_router(dashboard.router, prefix="/api")
 
 # Root route for basic status check
-@app.get("/")
-async def root():
-    """Root endpoint returning a simple status message."""
-    return {"status": "Blackletter Systems API running"}
+@app.get("/", response_class=HTMLResponse)
+async def root() -> str:
+    """Serve a simple landing page for the API."""
+    return (
+        "<!DOCTYPE html>"
+        "<html>"
+        "<head><title>Blackletter Systems</title></head>"
+        "<body>"
+        "<h1>Blackletter Systems API</h1>"
+        "<p>The backend is running.</p>"
+        "<p>See the <a href=\"/docs\">API docs</a>.</p>"
+        "</body>"
+        "</html>"
+    )
 
 # Health check
 @app.get("/health")


### PR DESCRIPTION
## Summary
- serve simple HTML page at API root to avoid blank site

## Testing
- `PYTHONPATH=. pytest backend/tests/test_review_endpoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6573ec200832f845de3da69ea97e5