### PR TITLE
Add Google Generative AI dependency

### DIFF
--- a/backend/tests/test_review_endpoint.py
+++ b/backend/tests/test_review_endpoint.py
@@ -5,7 +5,11 @@ from fastapi.testclient import TestClient
 from backend.main import app
 
 
-def test_review_endpoint_returns_results():
+def test_review_endpoint_returns_results(monkeypatch):
+    monkeypatch.setattr(
+        "backend.routers.contracts.ask_gemini",
+        lambda prompt: '{"summary": "ok", "risks": ["r1"]}',
+    )
     client = TestClient(app)
     pdf_path = Path("backend/tests/fixtures/uk_nda.pdf")
     with pdf_path.open("rb") as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ python-multipart
 pypdf
 python-docx
 tiktoken
+httpx==0.26.0
+google-generativeai


### PR DESCRIPTION
## Summary
- include google-generativeai in root requirements and pin httpx for compatibility
- mock Gemini call in review endpoint test

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a66326c5dc832fa790436576f42102