### PR TITLE
feat: expose API URL for frontend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import RedirectResponse
 from .routers import contracts, dashboard
 
 app = FastAPI(title="Blackletter Systems API")
@@ -17,15 +18,11 @@ app.add_middleware(
 app.include_router(contracts.router, prefix="/api")
 app.include_router(dashboard.router, prefix="/api")
 
-# Root route for basic status check
+# Root route redirects to API docs
 @app.get("/")
 async def root():
-    """Provide a simple landing response with service info."""
-    return {
-        "service": "blackletter-backend",
-        "status": "ok",
-        "docs": "/docs",
-    }
+    """Redirect to interactive API documentation."""
+    return RedirectResponse(url="/docs")
 
 # Health check
 @app.get("/health")

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=https://blackletter.onrender.com

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { API_URL, apiGet } from "@/lib/api";
 
 interface ContractEntry {
   id: string;
@@ -16,7 +17,7 @@ interface ContractEntry {
 export default function Dashboard() {
   const [file, setFile] = useState<File | null>(null);
   const [contracts, setContracts] = useState<ContractEntry[]>([]);
-  const apiBase = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const apiBase = API_URL;
 
   const runChecks = async () => {
     if (!file) return;
@@ -33,11 +34,7 @@ export default function Dashboard() {
         throw new Error(await uploadRes.text());
       }
       const { id } = await uploadRes.json();
-      const findingsRes = await fetch(`${apiBase}/api/contracts/${id}/findings`);
-      if (!findingsRes.ok) {
-        throw new Error(await findingsRes.text());
-      }
-      const data = await findingsRes.json();
+      const data = await apiGet(`/api/contracts/${id}/findings`);
       entry.id = id;
       entry.status = "done";
       entry.summary = data.summary;

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { API_URL, apiGet } from '@/lib/api';
 
 interface ReviewResult {
   summary: string;
@@ -13,7 +14,7 @@ export default function Home() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reportUrl, setReportUrl] = useState<string | null>(null);
-  const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  const apiBase = API_URL;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -34,11 +35,7 @@ export default function Home() {
         throw new Error(await uploadRes.text());
       }
       const { id } = await uploadRes.json();
-      const findingsRes = await fetch(`${apiBase}/api/contracts/${id}/findings`);
-      if (!findingsRes.ok) {
-        throw new Error(await findingsRes.text());
-      }
-      const data: ReviewResult = await findingsRes.json();
+      const data: ReviewResult = await apiGet(`/api/contracts/${id}/findings`);
       setAnalysis(data);
       setReportUrl(`${apiBase}/api/contracts/${id}/report`);
     } catch (err) {

--- a/frontend/app/upload/page.tsx
+++ b/frontend/app/upload/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { Navigation } from '@/components/navigation';
+import { API_URL, apiGet } from '@/lib/api';
 
 export default function UploadPage() {
   const [file, setFile] = useState<File | null>(null);
@@ -17,8 +18,8 @@ export default function UploadPage() {
 
   async function checkApiHealth() {
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/health`);
-      setApiHealth(res.ok ? 'ok' : 'error');
+      await apiGet('/health');
+      setApiHealth('ok');
     } catch (e) {
       setApiHealth('error');
     }
@@ -36,7 +37,7 @@ export default function UploadPage() {
     formData.append('file', file);
 
     try {
-      const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+      const apiBase = API_URL;
       const uploadRes = await fetch(`${apiBase}/api/contracts`, {
         method: 'POST',
         body: formData,
@@ -45,11 +46,7 @@ export default function UploadPage() {
         throw new Error(await uploadRes.text());
       }
       const { id } = await uploadRes.json();
-      const findingsRes = await fetch(`${apiBase}/api/contracts/${id}/findings`);
-      if (!findingsRes.ok) {
-        throw new Error(await findingsRes.text());
-      }
-      const data = await findingsRes.json();
+      const data = await apiGet(`/api/contracts/${id}/findings`);
       setResult({ ...data, reportUrl: `${apiBase}/api/contracts/${id}/report` });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,17 @@
+export const API_URL = process.env.NEXT_PUBLIC_API_URL!;
+
+export async function apiGet(path: string, init?: RequestInit) {
+  const res = await fetch(`${API_URL}${path}`, { ...init, cache: "no-store" });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}
+export async function apiPost(path: string, body: any, init?: RequestInit) {
+  const res = await fetch(`${API_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    ...init,
+  });
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- allow backend to redirect root to docs and keep CORS open
- wire frontend to backend with env-based API_URL and fetch helpers
- use shared API helper across pages

## Testing
- `python -m pytest backend/tests`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interrupted: interactive prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a668e29bb8832fa70bf3893cd1cc12