### PR TITLE
Fix backend tests package imports

### DIFF
--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,4 @@
+"""Test package for backend module.
+
+Ensures tests can be imported as part of the backend package when run
+standalone."""

--- a/backend/tests/test_llm_adapter_gemini.py
+++ b/backend/tests/test_llm_adapter_gemini.py
@@ -1,5 +1,13 @@
 import asyncio
-from backend.app.core.llm_adapter import LLMAdapter
+
+if __package__ is None or __package__ == "":
+    import os
+    import sys
+
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    from backend.app.core.llm_adapter import LLMAdapter  # type: ignore  # pragma: no cover
+else:
+    from ..app.core.llm_adapter import LLMAdapter
 
 class DummyResponse:
     def __init__(self, data):

--- a/backend/tests/test_review_endpoint.py
+++ b/backend/tests/test_review_endpoint.py
@@ -2,7 +2,14 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 
-from backend.main import app
+if __package__ is None or __package__ == "":
+    import os
+    import sys
+
+    sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    from backend.main import app  # type: ignore  # pragma: no cover
+else:
+    from ..main import app
 
 
 def test_review_endpoint_returns_results(monkeypatch):


### PR DESCRIPTION
## Summary
- avoid `ModuleNotFoundError` by appending project root when backend tests run standalone
- mark backend test directory as a package

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a66dc55230832fba3e5525e180ad68