### PR TITLE
chore: add root package scripts for next deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "name": "blackletter-root",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "blackletter-root",
+      "hasInstallScript": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "blackletter-root",
+  "private": true,
+  "scripts": {
+    "postinstall": "npm --prefix frontend install",
+    "build": "npm --prefix frontend run build",
+    "start": "npm --prefix frontend run start -- -p $PORT"
+  }
+}


### PR DESCRIPTION
## Summary
- add root-level package.json with postinstall, build, start scripts to run frontend
- generate package-lock.json for root package

## Testing
- `npm --prefix frontend test` *(fails: Missing script: "test")*
- `npm --prefix frontend run lint` *(interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a676a6477c832fa16133f6120e8a56