### PR TITLE
Fix: cleaned requirements.txt for Render

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
-fastapi
-uvicorn[standard]
-python-multipart
-pydantic
-requests
-python-dotenv
-jinja2
+fastapi==0.116.1
+uvicorn[standard]==0.35.0
+python-multipart==0.0.9
+pydantic==2.11.7
+requests==2.32.5
+python-dotenv==1.0.1
+jinja2==3.1.4


### PR DESCRIPTION
## Summary
- pin backend dependencies for Render deployment

## Testing
- `pytest` *(fails: FileNotFoundError: No such file or directory: 'backend/tests/fixtures/uk_nda.pdf')*

------
https://chatgpt.com/codex/tasks/task_e_68a692248c58832fa090bd67cfe69233