### PR TITLE
Pin backend dependency versions

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
-fastapi==0.116.1
-uvicorn[standard]==0.35.0
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
 python-multipart==0.0.9
-pydantic==2.11.7
-requests==2.32.5
+pydantic==2.6.4
+requests==2.32.3
 python-dotenv==1.0.1
 jinja2==3.1.4


### PR DESCRIPTION
## Summary
- pin FastAPI stack versions in `backend/requirements.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a69314e20c832fa65229f08ed4be2f