### PR TITLE
feat: add contract review proxy and chat page

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,4 @@
 # Environment Variables
 NEXT_PUBLIC_API_URL=http://localhost:8000
+BACKEND_URL=https://blackletter-backend.onrender.com/review
+GEMINI_API_KEY=your-google-key

--- a/frontend/app/api/review/route.ts
+++ b/frontend/app/api/review/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  try {
+    const backendUrl = process.env.BACKEND_URL || "https://blackletter-backend.onrender.com/review";
+    const body = await request.json();
+
+    const response = await fetch(backendUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Error talking to backend:", error);
+    return NextResponse.json(
+      { error: "Failed to connect to backend" },
+      { status: 500 }
+    );
+  }
+}
+
+export function GET() {
+  return NextResponse.json({ error: "Method not allowed" }, { status: 405 });
+}

--- a/frontend/app/gemini/page.tsx
+++ b/frontend/app/gemini/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function GeminiChat() {
+  const [prompt, setPrompt] = useState('');
+  const [contract, setContract] = useState('');
+  const [response, setResponse] = useState('');
+  const [review, setReview] = useState('');
+
+  // Gemini handler
+  const handleGemini = async () => {
+    const res = await fetch('/api/gemini', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt }),
+    });
+    const data = await res.json();
+    setResponse(data.reply || JSON.stringify(data));
+  };
+
+  // Contract review handler
+  const handleReview = async () => {
+    const res = await fetch('/api/review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contractText: contract }),
+    });
+    const data = await res.json();
+    setReview(JSON.stringify(data, null, 2));
+  };
+
+  return (
+    <div>
+      <h1>Gemini Chat</h1>
+      <textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        placeholder="Ask Gemini something..."
+      />
+      <button onClick={handleGemini}>Send to Gemini</button>
+      <p>Gemini Response: {response}</p>
+
+      <hr />
+
+      <h1>Contract Review</h1>
+      <textarea
+        value={contract}
+        onChange={(e) => setContract(e.target.value)}
+        placeholder="Paste contract text here..."
+      />
+      <button onClick={handleReview}>Submit for Review</button>
+      <pre>{review}</pre>
+    </div>
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export",
-    "start": "serve out"
+    "build": "next build",
+    "start": "next start"
   },
   "engines": { "node": ">=18 <21" },
   "dependencies": {

--- a/render.yaml
+++ b/render.yaml
@@ -10,3 +10,5 @@ services:
     envVars:
       - key: GEMINI_API_KEY
         sync: false
+      - key: BACKEND_URL
+        value: https://blackletter-backend.onrender.com/review


### PR DESCRIPTION
## Summary
- add Next.js API route to proxy contract review requests to FastAPI backend
- create Gemini chat page with contract review form
- document backend URL and Gemini API key in example env and render config

## Testing
- `npm run build`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a693d5324c832fbf24a283ecde06c9