### PR TITLE
Add Gemini API key configuration and test route

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-GEMINI_API_KEY=your_google_gemini_key_here
+GEMINI_API_KEY=your-google-gemini-api-key-here

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,9 +4,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 import os
+from dotenv import load_dotenv
 
-from .routers import contracts, issues, coverage, redlines
+from .routers import contracts, issues, coverage, redlines, gemini
 # from .routers import llm_test  # optional
+
+load_dotenv()  # only needed locally
 
 app = FastAPI(title="Blackletter")
 
@@ -31,4 +34,6 @@ app.include_router(contracts.router, prefix="/api", tags=["contracts"])
 app.include_router(issues.router,    prefix="/api", tags=["issues"])
 app.include_router(coverage.router,  prefix="/api", tags=["coverage"])
 app.include_router(redlines.router,  prefix="/api", tags=["redlines"])
+# Gemini endpoint for prompt testing
+app.include_router(gemini.router,    prefix="/api", tags=["gemini"])
 # app.include_router(llm_test.router,  prefix="/api", tags=["llm"])

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,3 +1,3 @@
-from . import contracts, issues, coverage, redlines
+from . import contracts, issues, coverage, redlines, gemini
 
-__all__ = ["contracts", "issues", "coverage", "redlines"]
+__all__ = ["contracts", "issues", "coverage", "redlines", "gemini"]

--- a/backend/routers/gemini.py
+++ b/backend/routers/gemini.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import requests
+from fastapi import APIRouter
+from pydantic import BaseModel
+from dotenv import load_dotenv
+
+
+load_dotenv()  # only needed locally
+
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+
+if not GEMINI_API_KEY:
+    raise ValueError("❌ GEMINI_API_KEY is not set in environment")
+
+
+def ask_gemini(prompt: str):
+    url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
+    headers = {
+        "Content-Type": "application/json",
+        "X-goog-api-key": GEMINI_API_KEY,
+    }
+    body = {"contents": [{"parts": [{"text": prompt}]}]}
+    response = requests.post(url, headers=headers, json=body)
+    return response.json()
+
+
+router = APIRouter()
+
+
+class GeminiRequest(BaseModel):
+    prompt: str
+
+
+@router.post("/gemini")
+def generate(req: GeminiRequest):
+    return ask_gemini(req.prompt)
+


### PR DESCRIPTION
## Summary
- document `GEMINI_API_KEY` in `.env.example`
- load GEMINI_API_KEY via `python-dotenv`
- add `/api/gemini` FastAPI route for prompt testing against Gemini API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6933cf528832f991f7bed4f1e9b1e