### PR TITLE
Set Cargo and Rustup directories in CI workflow

### DIFF
--- a/.github/workflows/rust_and_pip.yml
+++ b/.github/workflows/rust_and_pip.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Install Rust
         run: |
+          export CARGO_HOME=$HOME/.cargo
+          export RUSTUP_HOME=$HOME/.rustup
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source $HOME/.cargo/env
           rustc --version


### PR DESCRIPTION
## Summary
- configure Rust install step to use writable CARGO_HOME and RUSTUP_HOME directories

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_68a6ac00085c832fa903683970a8baf7