### PR TITLE
Ensure Rust tooling uses writable home directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      CARGO_HOME: ${{ env.HOME }}/.cargo
+      RUSTUP_HOME: ${{ env.HOME }}/.rustup
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Install Rust
         run: |
-          export CARGO_HOME=$HOME/.cargo
-          export RUSTUP_HOME=$HOME/.rustup
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source $HOME/.cargo/env
+          source "$CARGO_HOME/env"
           rustc --version
 
       # Other steps can be added here

--- a/.github/workflows/rust_and_pip.yml
+++ b/.github/workflows/rust_and_pip.yml
@@ -1,3 +1,4 @@
+
 name: Rust and Pip Setup
 
 on:
@@ -9,6 +10,9 @@ on:
 jobs:
   setup:
     runs-on: ubuntu-latest
+    env:
+      CARGO_HOME: ${{ env.HOME }}/.cargo
+      RUSTUP_HOME: ${{ env.HOME }}/.rustup
 
     steps:
       - name: Checkout repository
@@ -16,12 +20,12 @@ jobs:
 
       - name: Install Rust
         run: |
-          export CARGO_HOME=$HOME/.cargo
-          export RUSTUP_HOME=$HOME/.rustup
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source $HOME/.cargo/env
+          source "$CARGO_HOME/env"
           rustc --version
 
-      - name: Upgrade pip
+      - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install maturin
+          pip install -r backend/requirements.txt

--- a/render.yaml
+++ b/render.yaml
@@ -5,15 +5,25 @@ services:
     region: oregon
     plan: free
     buildCommand: |
-      # Install Python deps
-      pip install --upgrade pip
-      pip install -r backend/requirements.txt
+        # Define writable paths for Cargo and Rustup
+        export CARGO_HOME=$HOME/.cargo
+        export RUSTUP_HOME=$HOME/.rustup
 
-      # Install Node + build frontend
-      cd frontend
-      npm install
-      npm run build
-      cd ..
+        # Install Rust toolchain
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        source $CARGO_HOME/env
+        rustc --version
+
+        # Install Python deps
+        pip install --upgrade pip
+        pip install maturin
+        pip install -r backend/requirements.txt
+
+        # Install Node + build frontend
+        cd frontend
+        npm install
+        npm run build
+        cd ..
 
     startCommand: uvicorn backend.main:app --host 0.0.0.0 --port $PORT
 
@@ -22,3 +32,7 @@ services:
         value: 3.11.9
       - key: NODE_VERSION
         value: 18.18.0
+      - key: CARGO_HOME
+        value: /opt/render/home/.cargo
+      - key: RUSTUP_HOME
+        value: /opt/render/home/.rustup


### PR DESCRIPTION
## Summary
- configure GitHub workflows to install Rust under writable directories and keep CARGO_HOME/RUSTUP_HOME in env
- install Python dependencies, including maturin, alongside Rust setup
- define CARGO_HOME and RUSTUP_HOME in Render build config and install Rust during build

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6adc9b088832fbade6ccd584a25c5