### PR TITLE
Ensure precompiled pydantic-core and update render build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y curl build-essential
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+ENV TMPDIR=/tmp
+
+WORKDIR /app
+COPY . .
+RUN pip install --upgrade pip setuptools wheel
+RUN pip install -r requirements.txt
+
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.111.0
 uvicorn[standard]==0.29.0
 python-multipart==0.0.9
 pydantic==2.6.4
+pydantic-core==2.16.3 --only-binary=:all:
 requests==2.32.3
 python-dotenv==1.0.1
 jinja2==3.1.4

--- a/render.yaml
+++ b/render.yaml
@@ -5,8 +5,13 @@ services:
     region: oregon
     plan: free
     buildCommand: |
+      # Set temporary directory
+      export TMPDIR=/tmp
+
       # Install Python deps
-      pip install --upgrade pip
+      pip install --upgrade pip setuptools wheel
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      source $HOME/.cargo/env
       pip install -r backend/requirements.txt
 
       # Install Node + build frontend

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 chromadb
 openai
-pydantic
+pydantic==2.6.4
+pydantic-core==2.16.3 --only-binary=:all:
 fastapi
 uvicorn
 python-multipart


### PR DESCRIPTION
## Summary
- Pin pydantic to 2.6.4 and ensure pydantic-core only installs prebuilt wheels
- Add Rust, temporary directory, and upgraded build tools to Render build
- Provide optional Dockerfile for controlled builds

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'bs4')*
- `docker build -t my-app .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b19f9a0c832fa58e91eee33431a4