### PR TITLE
Create GDPR rules engine configuration

### DIFF
--- a/backend/rules/gdpr_rules.json
+++ b/backend/rules/gdpr_rules.json
@@ -1,0 +1,39 @@
+{
+  "version": "1.0",
+  "jurisdiction": ["UK", "EU"],
+  "meta": {
+    "purpose": "GDPR vendor contract compliance",
+    "scoring": {
+      "weights": {"critical": 4, "high": 3, "medium": 2, "low": 1},
+      "pass_threshold": 0.7
+    }
+  },
+  "rules": [
+    {
+      "id": "R01",
+      "name": "Data Processing Lawful Basis",
+      "article": "GDPR Article 6",
+      "severity": "critical",
+      "description": "Contract must specify lawful basis for personal data processing",
+      "required": true,
+      "checks": [
+        {
+          "type": "regex_any",
+          "field": "full_text",
+          "patterns": [
+            "lawful basis",
+            "Article 6\\(1\\)\\([a-f]\\)",
+            "legitimate interest",
+            "contractual necessity",
+            "consent.*processing"
+          ]
+        }
+      ],
+      "messages": {
+        "fail": "No clear lawful basis for data processing identified",
+        "warn": "Lawful basis mentioned but may need clarification"
+      },
+      "remediation": "Add clause: 'Data processing is necessary for performance of this contract pursuant to GDPR Article 6(1)(b)'"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Introduces `backend/rules/gdpr_rules.json` to define GDPR compliance rules. This initial version includes the "Data Processing Lawful Basis" (R01) rule, laying the groundwork for a real GDPR rules engine.

## Checklist

- [ ] No OpenAI / Ollama references remain; replaced with Gemini where applicable
- [ ] Tests updated or new tests added
- [ ] Lint and formatting (Black/Prettier) applied
- [ ] CI checks passing
- [ ] CHANGELOG updated if applicable

## How to test

Verify the existence and content of `backend/rules/gdpr_rules.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b43d30e-39a0-4e8a-ac19-e256b1d466f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b43d30e-39a0-4e8a-ac19-e256b1d466f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

