### PR TITLE
fix: configure base path for frontend UI

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,6 +2,8 @@
 const nextConfig = {
   output: 'export',
   trailingSlash: true,
+  basePath: '/app',
+  assetPrefix: '/app/',
   images: {
     unoptimized: true
   },
@@ -11,5 +13,4 @@ const nextConfig = {
     removeConsole: process.env.NODE_ENV === 'production',
   },
 };
-
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- set Next.js basePath and assetPrefix to /app so the exported UI loads correctly on Render

## Testing
- `pre-commit run --files frontend/next.config.js` *(fails: error: pathspec '24.0.0' did not match any file(s) known to git)*
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a87d94ea1c832f8633f2207379c4a1