### PR TITLE
Add OCR-enabled document ingestion utilities

### DIFF
--- a/apps/ingest/adapters/docx_adapter.py
+++ b/apps/ingest/adapters/docx_adapter.py
@@ -1,13 +1,12 @@
 from typing import List
-from docx import Document
 
+from ..document_ingestion import extract_text_from_docx, redact_pii
 from ..models import ContractChunk
-from ..utils import split_into_sections, count_tokens, new_id
+from ..utils import count_tokens, new_id, split_into_sections
 
 
 def ingest(path: str, contract_id: str) -> List[ContractChunk]:
-    doc = Document(path)
-    text = "\n".join(p.text for p in doc.paragraphs)
+    text = redact_pii(extract_text_from_docx(path))
     chunks: List[ContractChunk] = []
     for section, section_text in split_into_sections(text):
         chunk = ContractChunk(

--- a/apps/ingest/adapters/pdf_adapter.py
+++ b/apps/ingest/adapters/pdf_adapter.py
@@ -1,22 +1,33 @@
 from typing import List
-from pypdf import PdfReader
 
+import fitz  # PyMuPDF
+import pytesseract
+from pdf2image import convert_from_path
+
+from ..document_ingestion import redact_pii
 from ..models import ContractChunk
-from ..utils import split_into_sections, count_tokens, new_id
+from ..utils import count_tokens, new_id, split_into_sections
 
 
 def ingest(path: str, contract_id: str) -> List[ContractChunk]:
-    reader = PdfReader(path)
+    doc = fitz.open(path)
     chunks: List[ContractChunk] = []
-    for page_num, page in enumerate(reader.pages, start=1):
-        text = page.extract_text() or ""
+    for page_index in range(doc.page_count):
+        page = doc[page_index]
+        text = page.get_text() or ""
+        if not text.strip():
+            images = convert_from_path(
+                path, first_page=page_index + 1, last_page=page_index + 1
+            )
+            text = pytesseract.image_to_string(images[0])
+        text = redact_pii(text)
         for section, section_text in split_into_sections(text):
             chunk = ContractChunk(
                 id=new_id(),
                 contract_id=contract_id,
                 section=section,
                 text=section_text,
-                page=page_num,
+                page=page_index + 1,
                 tokens=count_tokens(section_text),
             )
             chunks.append(chunk)

--- a/apps/ingest/document_ingestion.py
+++ b/apps/ingest/document_ingestion.py
@@ -1,0 +1,73 @@
+"""Utilities for extracting text from various document formats.
+
+This module provides helper functions for the Document Ingestion
+component. It supports machine-readable PDFs, Microsoft Word documents
+(DOCX), and scanned PDFs via OCR. An optional helper for PII redaction is
+also included.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+import fitz  # PyMuPDF
+import pytesseract
+from docx import Document
+from pdf2image import convert_from_path
+
+
+def extract_text_from_pdf(path: str) -> str:
+    """Extract text from a machine-readable PDF.
+
+    Opens the PDF with PyMuPDF and concatenates text from all pages into a
+    single string.
+    """
+
+    text = ""
+    doc = fitz.open(path)
+    for page in doc:
+        page_text = page.get_text()
+        if not page_text.strip():
+            # Fallback to OCR for image-only pages
+            images = convert_from_path(
+                path, first_page=page.number + 1, last_page=page.number + 1
+            )
+            page_text = pytesseract.image_to_string(images[0])
+        text += page_text
+    return text
+
+
+def extract_text_from_docx(path: str) -> str:
+    """Extract text from a DOCX file."""
+
+    doc = Document(path)
+    return "\n".join(p.text for p in doc.paragraphs)
+
+
+def ocr_pdf(path: str) -> str:
+    """Run OCR on each page of a PDF and aggregate the text.
+
+    Adds page markers to preserve structure in the resulting text.
+    """
+
+    images = convert_from_path(path)
+    text_pages: List[str] = []
+    for i, img in enumerate(images, start=1):
+        txt = pytesseract.image_to_string(img)
+        text_pages.append(f"[[Page {i}]]\n{txt}")
+    return "\n".join(text_pages)
+
+
+_PII_PATTERNS = [
+    (re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"), "[EMAIL]"),
+    (re.compile(r"\+?\d[\d\s().-]{7,}\d"), "[PHONE]"),
+]
+
+
+def redact_pii(text: str) -> str:
+    """Redact simple PII patterns from text."""
+
+    for pattern, replacement in _PII_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text

--- a/apps/ingest/tests/test_document_ingestion.py
+++ b/apps/ingest/tests/test_document_ingestion.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import fitz
+from docx import Document
+
+from apps.ingest.document_ingestion import (extract_text_from_docx,
+                                            extract_text_from_pdf, redact_pii)
+
+
+def test_extract_text_from_pdf(tmp_path: Path):
+    pdf_path = tmp_path / "sample.pdf"
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Hello PDF")
+    doc.save(pdf_path)
+
+    text = extract_text_from_pdf(str(pdf_path))
+    assert "Hello PDF" in text
+
+
+def test_extract_text_from_docx(tmp_path: Path):
+    docx_path = tmp_path / "sample.docx"
+    doc = Document()
+    doc.add_paragraph("Hello DOCX")
+    doc.save(docx_path)
+
+    text = extract_text_from_docx(str(docx_path))
+    assert "Hello DOCX" in text
+
+
+def test_redact_pii():
+    text = "Reach me at john.doe@example.com or +1 555-123-4567."
+    redacted = redact_pii(text)
+    assert "[EMAIL]" in redacted
+    assert "[PHONE]" in redacted

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -17,6 +17,8 @@ pypdf==5.0.1
 pdfplumber==0.10.3
 pytesseract==0.3.10
 Pillow==10.4.0
+pdf2image==1.17.0
+PyMuPDF==1.24.7
 
 # Document Processing
 python-docx==1.1.0


### PR DESCRIPTION
## Summary
- add document_ingestion module with PDF, DOCX, and OCR text extraction helpers
- enable PII redaction in PDF and DOCX adapters
- include PyMuPDF and pdf2image dependencies

## Testing
- `pytest apps/ingest/tests/test_document_ingestion.py apps/ingest/tests/test_ingest.py`


------
https://chatgpt.com/codex/tasks/task_e_68aaa2bae688832fb0e04ea21046e4f3