### PR TITLE
Add RAG store stats and enable asyncio tests

### DIFF
--- a/backend/app/services/rag_store.py
+++ b/backend/app/services/rag_store.py
@@ -126,6 +126,15 @@ class RAGStore:
         # Sort by similarity and return top-k
         similarities.sort(key=lambda x: x[1], reverse=True)
         return similarities[:top_k]
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Return basic statistics about the stored chunks and documents."""
+        doc_ids = {chunk.doc_id for chunk in self.chunks.values()}
+        return {
+            "total_chunks": len(self.chunks),
+            "total_documents": len(doc_ids),
+            "document_ids": list(doc_ids),
+        }
     
     def get_context_around_chunk(self, chunk_id: str, context_chunks: int = 2) -> str:
         """

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 pythonpath = backend
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- add basic statistics helper to RAG store
- configure pytest for asyncio tests

## Testing
- `pytest apps/ingest/tests/test_ingest.py -q`
- `pytest backend/test_rag.py -q`
- `pytest tests/integration/test_health_endpoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa9600ae78832f9b9880a3cde18059